### PR TITLE
Set content-types based on Magic_mime

### DIFF
--- a/static/config.ml
+++ b/static/config.ml
@@ -57,8 +57,8 @@ let main =
     (console @-> stackv4 @-> kv_ro @-> kv_ro @-> clock @-> job)
 
 let () =
-  let ocamlfind = ["re.str"; "uri"; "tls"; "tls.mirage"; "mirage-http"] in
-  let opam = ["re"; "uri"; "tls"; "mirage-http"] in
+  let ocamlfind = ["re.str"; "uri"; "tls"; "tls.mirage"; "mirage-http"; "magic-mime"] in
+  let opam = ["re"; "uri"; "tls"; "mirage-http"; "magic-mime"] in
   add_to_ocamlfind_libraries ocamlfind;
   add_to_opam_packages opam;
   register "seal" [

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -30,10 +30,13 @@ module Dispatch (C:CONSOLE) (FS:KV_RO) (S:Cohttp_lwt.Server) = struct
     | [] | [""] -> dispatcher fs ["index.html"]
     | segments ->
       let path = String.concat "/" segments in
+      let mimetype = Magic_mime.lookup path in
+      let headers = Cohttp.Header.init () in
+      let headers = Cohttp.Header.add headers "content-type" mimetype in
       Lwt.catch
         (fun () ->
            read_fs fs path >>= fun body ->
-           S.respond_string ~status:`OK ~body ())
+           S.respond_string ~status:`OK ~body ~headers ())
         (fun exn ->
            S.respond_not_found ())
 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -76,7 +76,7 @@ struct
       log c "[%s] closing." cid
     in
     let http = Http.make ~conn_closed ~callback () in
-    Http.listen http flow () ()
+    Http.listen http flow
 
   let tls_init kv =
     X509.certificate kv `Default >>= fun cert ->


### PR DESCRIPTION
In reference to https://github.com/mirage/mirage-seal/issues/4
I also had to fix a call to Http.listen that I think came in with conduit 0.83
