### PR TITLE
increase default memory to 32 from 16

### DIFF
--- a/static/seal.xl
+++ b/static/seal.xl
@@ -3,7 +3,7 @@
 name = 'seal'
 kernel = 'mir-seal.xen'
 builder = 'linux'
-memory = 16
+memory = 32
 on_crash = 'preserve'
 
 # You must define the network and block interfaces manually.


### PR DESCRIPTION
Increase default memory to 32.  Fresh unikernels always run out of memory immediately on boot with 16, at least for me...
