### PR TITLE
Fix issue #20: index.html not loading for subfolders

### DIFF
--- a/static/config.ml
+++ b/static/config.ml
@@ -76,9 +76,9 @@ let http =
 
 let () =
   let ocamlfind = [
-    "uri"; "tls"; "tls.mirage"; "mirage-http"; "magic-mime"
+    "uri"; "tls"; "tls.mirage"; "mirage-http"; "magic-mime"; "re.str"
   ] in
-  let opam = ["uri"; "tls"; "mirage-http"; "magic-mime"] in
+  let opam = ["uri"; "tls"; "mirage-http"; "magic-mime"; "re"] in
   add_to_ocamlfind_libraries ocamlfind;
   add_to_opam_packages opam;
   register "seal" [

--- a/static/config.ml
+++ b/static/config.ml
@@ -76,9 +76,9 @@ let http =
 
 let () =
   let ocamlfind = [
-    "uri"; "tls"; "tls.mirage"; "mirage-http"; "magic-mime"; "re.str"
+    "uri"; "tls"; "tls.mirage"; "mirage-http"; "magic-mime"
   ] in
-  let opam = ["uri"; "tls"; "mirage-http"; "magic-mime"; "re"] in
+  let opam = ["uri"; "tls"; "mirage-http"; "magic-mime"] in
   add_to_ocamlfind_libraries ocamlfind;
   add_to_opam_packages opam;
   register "seal" [

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -29,7 +29,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         (Re_str.bounded_split (Re_str.regexp "/") (Uri.path uri) 0) in 
     Lwt.catch
       (fun () ->
-        read_fs fs path >>= fun mimetype, body ->
+        read_fs fs path >>= fun (mimetype, body) ->
          let headers = Cohttp.Header.add_opt header "content-type" mimetype in
          S.respond_string ~status:`OK ~body ~headers ())
       (fun exn ->

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -39,7 +39,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
       (fun () -> read_fs_path fs path) 
       (fun exn ->  
         Lwt.catch 
-        (fun () -> read_fs_path fs (path ^ "/index.html") 
+        (fun () -> read_fs_path fs (path ^ "/index.html"))
         (fun exn -> S.respond_not_found ()))
 
   (* Redirect to the same address, but in https. *)

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -115,7 +115,7 @@ struct
     tls_init keys >>= fun cfg ->
     (* 31536000 seconds is roughly a year *)
     let header = Cohttp.Header.init_with "Strict-Transport-Security" "max-age=31536000" in
-    let https flow = Dispatch_https.serve c flow (Dispatch_https.dispatcher ~header data) in
+    let https flow = Dispatch_https.serve c flow (Dispatch_https.dispatcher ~header data c) in
     let http  flow = Dispatch_http.serve  c flow Dispatch_http.redirect in
     S.listen_tcpv4 stack ~port:443 (with_tls c cfg ~f:https);
     S.listen_tcpv4 stack ~port:80  http;

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -21,7 +21,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))
         | `Ok bufs -> Lwt.return (Cstruct.copyv bufs)
-    in Lwt.nchoose (find_file name) (find_file (name ^ "/index.html")) 
+    in Lwt.choose [(find_file name); (find_file (name ^ "/index.html"))] 
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -14,7 +14,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
   let log c fmt = Printf.ksprintf (C.log c) fmt
 
   let read_fs fs name =
-    FS.size fs f_name >>= function
+    FS.size fs name >>= function
     | `Error (FS.Unknown_key _) ->
        Lwt.fail (Failure ("read " ^ name))
     | `Ok size ->

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -116,7 +116,7 @@ struct
     (* 31536000 seconds is roughly a year *)
     let header = Cohttp.Header.init_with "Strict-Transport-Security" "max-age=31536000" in
     let https flow = Dispatch_https.serve c flow (Dispatch_https.dispatcher ~header data ) in
-    let http  flow = Dispatch_http.serve  c flow Dispatch_http.redirect in
+    let http  flow = Dispatch_http.serve  c flow Dispatch_http.redirect c in
     S.listen_tcpv4 stack ~port:443 (with_tls c cfg ~f:https);
     S.listen_tcpv4 stack ~port:80  http;
     S.listen stack

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -21,7 +21,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))
         | `Ok bufs -> Lwt.return (Cstruct.copyv bufs)
-    in Lwt.choose [(find_file name); (find_file (name ^ "/index.html"))] 
+    in Lwt.choose [(find_file (name ^ "/index.html"); (find_file (name ^ "/index.html"))] 
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -21,7 +21,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))
         | `Ok bufs -> Lwt.return (Cstruct.copyv bufs)
-    in Lwt.choose [(find_file (name ^ "/index.html")); (find_file (name ^ "/index.html"))] 
+    in Lwt.nchoose [(find_file (name)); (find_file (name ^ "/index.html"))] 
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -30,10 +30,9 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
     Lwt.catch
       (fun () ->
         read_fs fs path >>= fun (mimetype, body) ->
-         let headers = Cohttp.Header.add_opt header "content-type" mimetype in
-         S.respond_string ~status:`OK ~body ~headers ())
-      (fun exn ->
-         S.respond_not_found ())
+          let headers = Cohttp.Header.add_opt header "content-type" mimetype in
+          S.respond_string ~status:`OK ~body ~headers ())
+      (fun exn -> S.respond_not_found ())
 
   (* Redirect to the same address, but in https. *)
   let redirect uri =

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -21,7 +21,9 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         FS.read fs f_name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ f_name))
         | `Ok bufs -> Lwt.return ((Magic_mime.lookup f_name), (Cstruct.copyv bufs))
-    in Lwt.choose [(find_file (name)); (find_file (name ^ "/index.html"))] 
+    in Lwt.catch 
+        (fun () -> find_file (name)) 
+        (fun exn -> find_file (name ^ "/index.html")) 
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -116,7 +116,7 @@ struct
     (* 31536000 seconds is roughly a year *)
     let header = Cohttp.Header.init_with "Strict-Transport-Security" "max-age=31536000" in
     let https flow = Dispatch_https.serve c flow (Dispatch_https.dispatcher ~header data ) in
-    let http  flow = Dispatch_http.serve  c flow Dispatch_http.redirect c in
+    let http  flow = Dispatch_http.serve  c flow (Dispatch_http.redirect c) in
     S.listen_tcpv4 stack ~port:443 (with_tls c cfg ~f:https);
     S.listen_tcpv4 stack ~port:80  http;
     S.listen stack

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -21,7 +21,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))
         | `Ok bufs -> Lwt.return (Cstruct.copyv bufs)
-    in Lwt.choose [(find_file (name ^ "/index.html"); (find_file (name ^ "/index.html"))] 
+    in Lwt.choose [(find_file (name ^ "/index.html")); (find_file (name ^ "/index.html"))] 
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -17,7 +17,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
     let name = FS.stat fs name >>= function   
       | `Ok {FS.directory = true} -> Lwt.return @@ name ^ "/index.html" 
       | `Ok {FS.directory = false} -> Lwt.return @@ name
-      | `Error (FS.Unknown_key _) -> Lwt.fail (Failure (name ^ " stat failure") 
+      | `Error (FS.Unknown_key _) -> Lwt.fail (Failure (name ^ " stat failure")) 
     in    
     name >>= FS.size fs name >>= function
     | `Error (FS.Unknown_key _) ->

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -16,9 +16,9 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
   let read_fs fs name =
     let find_file f_name = FS.size fs f_name >>= function
       | `Error (FS.Unknown_key _) ->
-        `Lwt.fail (Failure ("read " ^ name))
+        Lwt.fail (Failure ("read " ^ name))
       | `Ok size ->
-         FS.read fs name 0 (Int64.to_int size) >>= function
+        FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))
         | `Ok bufs -> Lwt.return (Cstruct.copyv bufs)
     in Lwt.nchoose (find_file name) (find_file (name ^ "/index.html")) 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -25,7 +25,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 
-    path = ListLabels.fold_left ~f:(fun a -> function "" -> a | b -> a ^ "/" ^ b) ~init:"" 
+    let path = ListLabels.fold_left ~f:(fun a -> function "" -> a | b -> a ^ "/" ^ b) ~init:"" 
         (Re_str.bounded_split (Re_str.regexp "/") @@ Uri.path uri) in 
     let mimetype = Magic_mime.lookup path in
     let headers = Cohttp.Header.add_opt header "content-type" mimetype in

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -26,7 +26,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
   (* dispatch files *)
   let dispatcher fs ?header uri = 
     let path = ListLabels.fold_left ~f:(fun a -> function "" -> a | b -> a ^ "/" ^ b) ~init:"" 
-        (Re_str.bounded_split (Re_str.regexp "/") @@ Uri.path uri) in 
+        (Re_str.bounded_split (Re_str.regexp "/") (Uri.path uri) 0) in 
     let mimetype = Magic_mime.lookup path in
     let headers = Cohttp.Header.add_opt header "content-type" mimetype in
     Lwt.catch

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -115,7 +115,7 @@ struct
     tls_init keys >>= fun cfg ->
     (* 31536000 seconds is roughly a year *)
     let header = Cohttp.Header.init_with "Strict-Transport-Security" "max-age=31536000" in
-    let https flow = Dispatch_https.serve c flow (Dispatch_https.dispatcher ~header data c) in
+    let https flow = Dispatch_https.serve c flow (Dispatch_https.dispatcher ~header data ) in
     let http  flow = Dispatch_http.serve  c flow Dispatch_http.redirect in
     S.listen_tcpv4 stack ~port:443 (with_tls c cfg ~f:https);
     S.listen_tcpv4 stack ~port:80  http;

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -20,7 +20,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
       | `Ok size ->
         FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))
-        | `Ok bufs -> Lwt.return ((Magic_mime.lookup f_name), (Cstruct.copyv bufs))
+        | `Ok bufs -> Lwt.return ((Magic_mime.lookup name), (Cstruct.copyv bufs))
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -32,7 +32,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
     Lwt.catch
       (fun () ->
         read_fs fs path >>= fun body ->
-         S.respond_string ~status:`OK ~body ~headers ())
+         S.respond_string ~status:`OK ~body:path ~headers ())
       (fun exn ->
          S.respond_string ~status:`OK ~body:path ~headers ())
 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -39,7 +39,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
       (fun () -> read_fs_path fs path) 
       (fun exn ->  
         Lwt.catch 
-        (fun () -> read_fs_path fs path) 
+        (fun () -> read_fs_path fs (path ^ "/index.html") 
         (fun exn -> S.respond_not_found ()))
 
   (* Redirect to the same address, but in https. *)

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -21,7 +21,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))
         | `Ok bufs -> Lwt.return (Cstruct.copyv bufs)
-    in Lwt.nchoose [(find_file (name)); (find_file (name ^ "/index.html"))] 
+    in Lwt.choose [(find_file (name)); (find_file (name ^ "/index.html"))] 
 
   (* dispatch files *)
   let dispatcher fs ?header uri = 

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -16,7 +16,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
   let read_fs fs name =
     let find_file f_name = FS.size fs f_name >>= function
       | `Error (FS.Unknown_key _) ->
-        Lwt.fail (Failure ("read " ^ name))
+        log "Failure: " ^ f_name; Lwt.fail (Failure ("read " ^ name))
       | `Ok size ->
         FS.read fs name 0 (Int64.to_int size) >>= function
         | `Error (FS.Unknown_key _) -> Lwt.fail (Failure ("read " ^ name))

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -34,7 +34,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
         read_fs fs path >>= fun body ->
          S.respond_string ~status:`OK ~body ~headers ())
       (fun exn ->
-         S.respond_string ~status:`OK path ~headers ())
+         S.respond_string ~status:`OK ~body:path ~headers ())
 
   (* Redirect to the same address, but in https. *)
   let redirect uri =

--- a/static/dispatch.ml
+++ b/static/dispatch.ml
@@ -30,6 +30,7 @@ module Dispatch (C: CONSOLE) (FS: KV_RO) (S: HTTP) = struct
     let mimetype = match Magic_mime.lookup path with
       | "application/octet-stream" -> Magic_mime.lookup (path ^ "/index.html")
       | mime -> mime 
+    in 
     let headers = Cohttp.Header.add_opt header "content-type" mimetype in
     Lwt.catch
       (fun () ->


### PR DESCRIPTION
I've attempted to fix my issue. Code changed to normalize the path and then attempts to load /index.html if the initial attempt to find the KV fails.  
